### PR TITLE
Use new puppet-lint gem

### DIFF
--- a/puppet-lint-lookup_in_parameter-check.gemspec
+++ b/puppet-lint-lookup_in_parameter-check.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'puppet-lint', '>= 3', '< 5'
+  spec.add_dependency 'puppetlabs-puppet-lint', '~> 5.0'
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Using the now-maintained puppetlabs-puppet-lint over puppet-lint

